### PR TITLE
chore: supports symfony version ^7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,17 +31,17 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
-        "symfony/config": "^5.4 | ^6.0",
-        "symfony/console": "^5.4 | ^6.0",
-        "symfony/dependency-injection": "^5.4 | ^6.0",
-        "symfony/http-kernel": "^5.4 | ^6.0",
-        "symfony/mailer": "^5.4 | ^6.0",
-        "symfony/twig-bridge": "^5.4 | ^6.0",
-        "symfony/yaml": "^5.4 | ^6.0"
+        "php": ">=8.1",
+        "symfony/config": "^6.4 | ^7.4",
+        "symfony/console": "^6.4 | ^7.4",
+        "symfony/dependency-injection": "^6.4 | ^7.4",
+        "symfony/http-kernel": "^6.4 | ^7.4",
+        "symfony/mailer": "^6.4 | ^7.4",
+        "symfony/twig-bridge": "^6.4 | ^7.4",
+        "symfony/yaml": "^6.4 | ^7.4"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^5.4 | ^6.0"
+        "symfony/phpunit-bridge": "^6.4 | ^7.4"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
1. adds support for symfony version ^7.4
2. drops support for symfony versions lower than 6.4 as well